### PR TITLE
More markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Features
  - Visualizing stereo pair image (currently expects one side-by-side image, or duplicates the same image to each eye)
  - Visualizing camera image (projects out from camera location)
  - Visualizing visualization messages (All [types](http://wiki.ros.org/rviz/DisplayTypes/Marker) are at least basically supported, but may not perform identically to rviz)
+   - to see a variety of markers, run `roslaunch vrviz turtlebot_demo.launch silly_shapes:=true`
 
 Limitations
 -----------

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ library, which is included in `openvr_library` and sdl2 which is included in `sd
 The code is designed to be used in ROS, and has been tested in ROS Kinetic on Ubuntu 16.04. Instructions for installing ROS can be found [here](http://wiki.ros.org/ROS/Installation) and other than the turtlebot demo, all ROS dependencies should be covered by `ros-kinetic-desktop-full`.
 
 The non-ROS dependencies include GLEW for rendering and [assimp](http://www.assimp.org/) for loading URDF robot models with Collada meshes.
-These should be able to be installed with:
+These should be able to be installed with rosdep or with:
 ```
 sudo apt-get install libglew-dev libassimp-dev
 ```
@@ -64,19 +64,19 @@ roslaunch vrviz video_demo.launch video_file:=/path/to/bbb_clip_sbs.mp4
 Features
 --------
  - The default RViz 1m grid
- - Scaling the VR world relative to the ROS world (currently set by rosparam at startup)
+ - Scaling the VR world relative to the ROS world (set by rosparam at startup)
  - Loading a robot model from the parameter server with `load_robot:=true`
  - Visualizing TF's (currently only TF's that have been referenced somewhere)
- - Visualizing PointCloud2 messages (currently expecting color)
+ - Visualizing PointCloud2 messages (works with color or intensity, otherwise sets constant color)
  - Visualizing stereo pair image (currently expects one side-by-side image, or duplicates the same image to each eye)
- - Visualizing visualization messages (currently expecting cube, sphere, cylinder or text)
+ - Visualizing camera image (projects out from camera location)
+ - Visualizing visualization messages (All [types](http://wiki.ros.org/rviz/DisplayTypes/Marker) are at least basically supported, but may not perform identically to rviz)
 
 Limitations
 -----------
  - The code is very much a work in progress, and many features are partially or inefficiently implemented.
  - The [SteamVR support for Ubuntu](https://github.com/ValveSoftware/SteamVR-for-Linux) is still in Beta, so be careful.
- - Currently only supports one of each message type. This can be worked around by, for example, concatenating a bunch of point clouds in another node and then sending the big cloud into VRViz.
- - Images are just overlayed directly on the user's eyes, blocking view of the scene. Images could/should be placed in a location based on the camera info, but this is not implemented yet.
+ - Currently only supports one of each message type. This can be worked around by, for example, concatenating a bunch of point clouds in another node and then sending the big cloud into VRViz. Also multiple visualization messages could be mapped to the one receiver, as it should update based on namespace and ID.
  - Please feel free to open a feature request or add a pull request, there are lots of little improvements that we have not gotten around to but if there's a desire for them we would be happy to try.
 
 Vulkan

--- a/vrviz/launch/turtlebot_demo.launch
+++ b/vrviz/launch/turtlebot_demo.launch
@@ -1,5 +1,6 @@
 
 <launch>
+    <arg name="silly_shapes" default="false"/>
 
     <include file="$(find vrviz)/launch/vrviz.launch">
         <arg name="cloud_remap" value="/camera/depth/points"/>
@@ -20,7 +21,9 @@
       <arg name="gui" value="false"/>
     </include>
 
-    <node pkg="vrviz" type="marker_test" name="marker_test" />
+    <node pkg="vrviz" type="marker_test" name="marker_test" >
+        <param name="silly_shapes" value="$(arg silly_shapes)" />
+    </node>
 
 	
 </launch>

--- a/vrviz/launch/turtlebot_demo.launch
+++ b/vrviz/launch/turtlebot_demo.launch
@@ -4,13 +4,14 @@
     <include file="$(find vrviz)/launch/vrviz.launch">
         <arg name="cloud_remap" value="/camera/depth/points"/>
         <arg name="marker_remap" value="/marker_array"/>
-        <arg name="image_remap" value="/camera/rgb/image_raw"/>
+        <!--arg name="image_remap" value="/camera/rgb/image_raw"/-->
         <arg name="scaling_factor" value="1.0"/>
         <arg name="point_size" value="1"/>
         <arg name="twist_remap" value="/cmd_vel_mux/input/teleop"/>
         <arg name="load_robot" value="true"/>
         <arg name="show_tf" value="true"/>
-        <arg name="hud_dist" default="0.5"/>
+        <arg name="hud_dist" value="0.5"/>
+        <arg name="manual_image_copy" value="true"/>
     </include>
     <node pkg="tf" type="static_transform_publisher" name="coordinate_vrviz_base_base"
         args="0 0 0 0 0 1.57079632679 odom vrviz_base  10" />

--- a/vrviz/src/marker_test.cpp
+++ b/vrviz/src/marker_test.cpp
@@ -10,7 +10,7 @@
 ros::Publisher g_marker_pub;
 
 /// Params
-bool silly_shapes = true;
+bool silly_shapes = false;
 std::string shape_frame = "/vrviz_base";
 
 std::vector<std::string> tf_cache;
@@ -172,9 +172,9 @@ void publishCallback(const ros::TimerEvent&)
         marker.id = 1;
         marker.type = visualization_msgs::Marker::LINE_LIST;
         marker.action = visualization_msgs::Marker::ADD;
-        marker.pose.position.x = .1;
-        marker.pose.position.y = .2;
-        marker.pose.position.z =-.7;
+        marker.pose.position.x = 0.5;
+        marker.pose.position.y = 0.7;
+        marker.pose.position.z =-0.5;
         marker.scale.x = 0.01;
         marker.scale.y = 1;
         marker.scale.z = 1;
@@ -214,9 +214,9 @@ void publishCallback(const ros::TimerEvent&)
         marker.id = 2;
         marker.type = visualization_msgs::Marker::LINE_STRIP;
         marker.action = visualization_msgs::Marker::ADD;
-        marker.pose.position.x = .2;
-        marker.pose.position.y = .1;
-        marker.pose.position.z =-.5;
+        marker.pose.position.x = 0.5;
+        marker.pose.position.y = 0.7;
+        marker.pose.position.z =-0.5;
         marker.scale.x = 0.01;
         marker.scale.y = 1;
         marker.scale.z = 1;
@@ -247,9 +247,9 @@ void publishCallback(const ros::TimerEvent&)
         marker.id = 1;
         marker.type = visualization_msgs::Marker::CUBE_LIST;
         marker.action = visualization_msgs::Marker::ADD;
-        marker.pose.position.x = .2;
-        marker.pose.position.y = .1;
-        marker.pose.position.z =-.5;
+        marker.pose.position.x = 0.5;
+        marker.pose.position.y = 0.7;
+        marker.pose.position.z =-0.5;
         marker.scale.x = 0.01;
         marker.scale.y = 0.02;
         marker.scale.z = 0.03;
@@ -286,9 +286,9 @@ void publishCallback(const ros::TimerEvent&)
         marker.id = 2;
         marker.type = visualization_msgs::Marker::SPHERE_LIST;
         marker.action = visualization_msgs::Marker::ADD;
-        marker.pose.position.x = .2;
-        marker.pose.position.y = .1;
-        marker.pose.position.z =-.5;
+        marker.pose.position.x = 0.5;
+        marker.pose.position.y = 0.7;
+        marker.pose.position.z =-0.5;
         marker.scale.x = 0.02;
         marker.scale.y = 1;
         marker.scale.z = 1;
@@ -319,9 +319,9 @@ void publishCallback(const ros::TimerEvent&)
         marker.id = 3;
         marker.type = visualization_msgs::Marker::POINTS;
         marker.action = visualization_msgs::Marker::ADD;
-        marker.pose.position.x = .2;
-        marker.pose.position.y = .1;
-        marker.pose.position.z =-.5;
+        marker.pose.position.x = 0.5;
+        marker.pose.position.y = 0.7;
+        marker.pose.position.z =-0.5;
         marker.scale.x = 0.02;
         marker.scale.y = 1;
         marker.scale.z = 1;

--- a/vrviz/src/marker_test.cpp
+++ b/vrviz/src/marker_test.cpp
@@ -352,34 +352,35 @@ void publishCallback(const ros::TimerEvent&)
     for(int idx=0;idx<tf_cache.size();idx++){
         msg.markers.push_back(frame_label(tf_cache[idx]));
     }
-//    {
-//        visualization_msgs::Marker marker;
-//        marker.header.frame_id = "vrviz_intermediate";
-//        marker.header.stamp = ros::Time::now();
-//        marker.ns = "marker_test_mesh";
-//        marker.id = 0;
-//        marker.type = visualization_msgs::Marker::MESH_RESOURCE;
-//        marker.action = visualization_msgs::Marker::ADD;
-//        marker.pose.position.x = 0.0;
-//        marker.pose.position.y = 0.0;
-//        marker.pose.position.z = 0.0;
-//        marker.pose.orientation.x = 0.0;
-//        marker.pose.orientation.y = 0.0;
-//        marker.pose.orientation.z = 0.0;
-//        marker.pose.orientation.w = 1.0;
-//        marker.scale.x = 1.0;
-//        marker.scale.y = 1.0;
-//        marker.scale.z = 1.0;
-//        marker.color.r = 0.0;
-//        marker.color.g = 0.0;
-//        marker.color.b = 0.0;
-//        marker.color.a = 1.0;
-//        marker.frame_locked = true;
-//        marker.mesh_resource = "package://vrviz/meshes/flag.dae";
-//        //marker.mesh_resource = "package://turtlebot_description/meshes/stacks/hexagons/plate_top.dae";
-//        marker.mesh_use_embedded_materials = true;
-//        msg.markers.push_back(marker);
-//    }
+    if(silly_shapes)
+    {
+        visualization_msgs::Marker marker;
+        marker.header.frame_id = shape_frame;
+        marker.header.stamp = ros::Time::now();
+        marker.ns = "marker_test_mesh";
+        marker.id = 0;
+        marker.type = visualization_msgs::Marker::MESH_RESOURCE;
+        marker.action = visualization_msgs::Marker::ADD;
+        marker.pose.position.x = 0.0;
+        marker.pose.position.y = 0.0;
+        marker.pose.position.z = 0.0;
+        marker.pose.orientation.x = 0.0;
+        marker.pose.orientation.y = 0.0;
+        marker.pose.orientation.z = 0.0;
+        marker.pose.orientation.w = 1.0;
+        marker.scale.x = 1.0;
+        marker.scale.y = 1.0;
+        marker.scale.z = 1.0;
+        marker.color.r = 0.0;
+        marker.color.g = 0.0;
+        marker.color.b = 0.0;
+        marker.color.a = 1.0;
+        marker.frame_locked = true;
+        //marker.mesh_resource = "package://vrviz/meshes/flag.dae";
+        marker.mesh_resource = "package://turtlebot_description/meshes/stacks/hexagons/plate_top.dae";
+        marker.mesh_use_embedded_materials = true;
+        msg.markers.push_back(marker);
+    }
   g_marker_pub.publish(msg);
 
   static tf::TransformBroadcaster br;

--- a/vrviz/src/marker_test.cpp
+++ b/vrviz/src/marker_test.cpp
@@ -192,6 +192,15 @@ void publishCallback(const ros::TimerEvent&)
             pt.y = sin(angle)/3.0;
             pt.z = angle/10.0;
             marker.points.push_back(pt);
+            std_msgs::ColorRGBA color;
+            color.a = 1.0;
+            color.r = angle/(2*M_PI);
+            color.g = 1.0 - angle/(2*M_PI);
+            color.b = 0.0;
+//            color.r = (sin(angle*234634623.)+1)/2.0;
+//            color.g = (sin(angle*454737257.)+1)/2.0;
+//            color.b = (sin(angle*372754645.)+1)/2.0;
+            marker.colors.push_back(color);
         }
         msg.markers.push_back(marker);
     }

--- a/vrviz/src/marker_test.cpp
+++ b/vrviz/src/marker_test.cpp
@@ -9,6 +9,10 @@
 
 ros::Publisher g_marker_pub;
 
+/// Params
+bool silly_shapes = true;
+std::string shape_frame = "/vrviz_base";
+
 std::vector<std::string> tf_cache;
 
 visualization_msgs::Marker frame_label(std::string frame_id){
@@ -37,7 +41,7 @@ void publishCallback(const ros::TimerEvent&)
     {
         /// Add some instructions for the demo
         visualization_msgs::Marker marker;
-        marker.header.frame_id = "/vrviz_base";
+        marker.header.frame_id = shape_frame;
         marker.header.stamp = ros::Time::now();
         marker.ns = "marker_text";
         marker.id = 0;
@@ -54,81 +58,287 @@ void publishCallback(const ros::TimerEvent&)
         marker.text="USE WAND TRIGGER TO DRIVE";
         msg.markers.push_back(marker);
     }
-//    {
-//        /// Add some silly shapes
-//        visualization_msgs::Marker marker;
-//        marker.header.frame_id = "/vrviz_base";
-//        marker.header.stamp = ros::Time::now();
-//        marker.ns = "sphere";
-//        marker.id = 0;
-//        marker.type = visualization_msgs::Marker::SPHERE;
-//        marker.action = visualization_msgs::Marker::ADD;
-//        marker.pose.position.x = 0.2;
-//        marker.pose.position.y = 0.7;
-//        marker.pose.position.z =-0.2;
-//        marker.scale.x = 0.10;
-//        marker.scale.y = 0.10;
-//        marker.scale.z = 0.10;
-//        marker.pose.orientation.x = 0.0;
-//        marker.pose.orientation.y = 0.0;
-//        marker.pose.orientation.z = 0.0;
-//        marker.pose.orientation.w = 1.0;
-//        marker.color.r=1.0;
-//        marker.color.g=0.0;
-//        marker.color.b=0.0;
-//        marker.color.a=1.0;
-//        msg.markers.push_back(marker);
-//    }
-//    {
-//        /// Add some silly shapes
-//        visualization_msgs::Marker marker;
-//        marker.header.frame_id = "/vrviz_base";
-//        marker.header.stamp = ros::Time::now();
-//        marker.ns = "cube";
-//        marker.id = 0;
-//        marker.type = visualization_msgs::Marker::CUBE;
-//        marker.action = visualization_msgs::Marker::ADD;
-//        marker.pose.position.x =-0.5;
-//        marker.pose.position.y = 0.7;
-//        marker.pose.position.z =-0.5;
-//        marker.scale.x = 0.3;
-//        marker.scale.y = 0.5;
-//        marker.scale.z = 0.7;
-//        marker.pose.orientation.x = 0.146629;
-//        marker.pose.orientation.y = 0.311454;
-//        marker.pose.orientation.z = 0.733143;
-//        marker.pose.orientation.w = 0.586514;
-//        marker.color.r=0.0;
-//        marker.color.g=1.0;
-//        marker.color.b=0.0;
-//        marker.color.a=1.0;
-//        msg.markers.push_back(marker);
-//    }
-//    {
-//        /// Add some silly shapes
-//        visualization_msgs::Marker marker;
-//        marker.header.frame_id = "/vrviz_base";
-//        marker.header.stamp = ros::Time::now();
-//        marker.ns = "cylinder";
-//        marker.id = 0;
-//        marker.type = visualization_msgs::Marker::CYLINDER;
-//        marker.action = visualization_msgs::Marker::ADD;
-//        marker.pose.position.x = 0.5;
-//        marker.pose.position.y = 0.7;
-//        marker.pose.position.z =-0.5;
-//        marker.scale.x = 0.2;
-//        marker.scale.y = 0.2;
-//        marker.scale.z = 0.5;
-//        marker.pose.orientation.x = 0.443047;
-//        marker.pose.orientation.y = 0.235269;
-//        marker.pose.orientation.z = 0.553809;
-//        marker.pose.orientation.w = 0.664570;
-//        marker.color.r=0.0;
-//        marker.color.g=0.0;
-//        marker.color.b=1.0;
-//        marker.color.a=1.0;
-//        msg.markers.push_back(marker);
-//    }
+    if(silly_shapes)
+    {
+        /// Add some silly shapes
+        visualization_msgs::Marker marker;
+        marker.header.frame_id = shape_frame;
+        marker.header.stamp = ros::Time::now();
+        marker.ns = "sphere";
+        marker.id = 0;
+        marker.type = visualization_msgs::Marker::SPHERE;
+        marker.action = visualization_msgs::Marker::ADD;
+        marker.pose.position.x = 0.2;
+        marker.pose.position.y = 0.7;
+        marker.pose.position.z =-0.2;
+        marker.scale.x = 0.10;
+        marker.scale.y = 0.10;
+        marker.scale.z = 0.10;
+        marker.pose.orientation.x = 0.0;
+        marker.pose.orientation.y = 0.0;
+        marker.pose.orientation.z = 0.0;
+        marker.pose.orientation.w = 1.0;
+        marker.color.r=1.0;
+        marker.color.g=0.0;
+        marker.color.b=0.0;
+        marker.color.a=1.0;
+        msg.markers.push_back(marker);
+    }
+    if(silly_shapes)
+    {
+        /// Add some silly shapes
+        visualization_msgs::Marker marker;
+        marker.header.frame_id = shape_frame;
+        marker.header.stamp = ros::Time::now();
+        marker.ns = "cube";
+        marker.id = 0;
+        marker.type = visualization_msgs::Marker::CUBE;
+        marker.action = visualization_msgs::Marker::ADD;
+        marker.pose.position.x =-0.5;
+        marker.pose.position.y = 0.7;
+        marker.pose.position.z =-0.5;
+        marker.scale.x = 0.3;
+        marker.scale.y = 0.5;
+        marker.scale.z = 0.7;
+        marker.pose.orientation.x = 0.146629;
+        marker.pose.orientation.y = 0.311454;
+        marker.pose.orientation.z = 0.733143;
+        marker.pose.orientation.w = 0.586514;
+        marker.color.r=0.0;
+        marker.color.g=1.0;
+        marker.color.b=0.0;
+        marker.color.a=1.0;
+        msg.markers.push_back(marker);
+    }
+    if(silly_shapes)
+    {
+        /// Add some silly shapes
+        visualization_msgs::Marker marker;
+        marker.header.frame_id = shape_frame;
+        marker.header.stamp = ros::Time::now();
+        marker.ns = "cylinder";
+        marker.id = 0;
+        marker.type = visualization_msgs::Marker::CYLINDER;
+        marker.action = visualization_msgs::Marker::ADD;
+        marker.pose.position.x = 0.5;
+        marker.pose.position.y = 0.7;
+        marker.pose.position.z =-0.5;
+        marker.scale.x = 0.2;
+        marker.scale.y = 0.2;
+        marker.scale.z = 0.5;
+        marker.pose.orientation.x = 0.443047;
+        marker.pose.orientation.y = 0.235269;
+        marker.pose.orientation.z = 0.553809;
+        marker.pose.orientation.w = 0.664570;
+        marker.color.r=0.0;
+        marker.color.g=0.0;
+        marker.color.b=1.0;
+        marker.color.a=1.0;
+        msg.markers.push_back(marker);
+    }
+    if(silly_shapes)
+    {
+        /// Add some silly shapes
+        visualization_msgs::Marker marker;
+        marker.header.frame_id = shape_frame;
+        marker.header.stamp = ros::Time::now();
+        marker.ns = "arrow";
+        marker.id = 1;
+        marker.type = visualization_msgs::Marker::ARROW;
+        marker.action = visualization_msgs::Marker::ADD;
+        marker.pose.position.x = .1;
+        marker.pose.position.y = .2;
+        marker.pose.position.z =-.7;
+        marker.scale.x = 1.0/3.0;
+        marker.scale.y = 0.1;
+        marker.scale.z = 0.1;
+        marker.pose.orientation.x = 0.443047;
+        marker.pose.orientation.y = 0.235269;
+        marker.pose.orientation.z = 0.553809;
+        marker.pose.orientation.w = 0.664570;
+        marker.color.r=1.0;
+        marker.color.g=0.0;
+        marker.color.b=1.0;
+        marker.color.a=1.0;
+        msg.markers.push_back(marker);
+    }
+    if(silly_shapes)
+    {
+        /// Add some silly shapes
+        visualization_msgs::Marker marker;
+        marker.header.frame_id = shape_frame;
+        marker.header.stamp = ros::Time::now();
+        marker.ns = "line";
+        marker.id = 1;
+        marker.type = visualization_msgs::Marker::LINE_LIST;
+        marker.action = visualization_msgs::Marker::ADD;
+        marker.pose.position.x = .1;
+        marker.pose.position.y = .2;
+        marker.pose.position.z =-.7;
+        marker.scale.x = 0.01;
+        marker.scale.y = 1;
+        marker.scale.z = 1;
+        marker.pose.orientation.x = 0.443047;
+        marker.pose.orientation.y = 0.235269;
+        marker.pose.orientation.z = 0.553809;
+        marker.pose.orientation.w = 0.664570;
+        marker.color.r=1.0;
+        marker.color.g=0.0;
+        marker.color.b=0.0;
+        marker.color.a=1.0;
+        for(float angle=0.0;angle<2*M_PI;angle+=0.15){
+            geometry_msgs::Point pt;
+            pt.x = cos(angle)/3.0;
+            pt.y = sin(angle)/3.0;
+            pt.z = angle/10.0;
+            marker.points.push_back(pt);
+        }
+        msg.markers.push_back(marker);
+    }
+    if(silly_shapes)
+    {
+        /// Add some silly shapes
+        visualization_msgs::Marker marker;
+        marker.header.frame_id = shape_frame;
+        marker.header.stamp = ros::Time::now();
+        marker.ns = "line";
+        marker.id = 2;
+        marker.type = visualization_msgs::Marker::LINE_STRIP;
+        marker.action = visualization_msgs::Marker::ADD;
+        marker.pose.position.x = .2;
+        marker.pose.position.y = .1;
+        marker.pose.position.z =-.5;
+        marker.scale.x = 0.01;
+        marker.scale.y = 1;
+        marker.scale.z = 1;
+        marker.pose.orientation.x = 0.443047;
+        marker.pose.orientation.y = 0.235269;
+        marker.pose.orientation.z = 0.553809;
+        marker.pose.orientation.w = 0.664570;
+        marker.color.r=1.0;
+        marker.color.g=1.0;
+        marker.color.b=0.0;
+        marker.color.a=1.0;
+        for(float angle=0.0;angle<2*M_PI;angle+=0.15){
+            geometry_msgs::Point pt;
+            pt.x = cos(angle)/4.0;
+            pt.y = sin(angle)/4.0;
+            pt.z = angle/10.0;
+            marker.points.push_back(pt);
+        }
+        msg.markers.push_back(marker);
+    }
+    if(silly_shapes)
+    {
+        /// Add some silly shapes
+        visualization_msgs::Marker marker;
+        marker.header.frame_id = shape_frame;
+        marker.header.stamp = ros::Time::now();
+        marker.ns = "lists";
+        marker.id = 1;
+        marker.type = visualization_msgs::Marker::CUBE_LIST;
+        marker.action = visualization_msgs::Marker::ADD;
+        marker.pose.position.x = .2;
+        marker.pose.position.y = .1;
+        marker.pose.position.z =-.5;
+        marker.scale.x = 0.01;
+        marker.scale.y = 0.02;
+        marker.scale.z = 0.03;
+        marker.pose.orientation.x = 0.443047;
+        marker.pose.orientation.y = 0.235269;
+        marker.pose.orientation.z = 0.553809;
+        marker.pose.orientation.w = 0.664570;
+        marker.color.r=0.0;
+        marker.color.g=1.0;
+        marker.color.b=1.0;
+        marker.color.a=1.0;
+        for(float angle=0.0;angle<2*M_PI;angle+=0.15){
+            geometry_msgs::Point pt;
+            pt.x = cos(angle)/5.0;
+            pt.y = sin(angle)/5.0;
+            pt.z = angle/10.0;
+            marker.points.push_back(pt);
+            std_msgs::ColorRGBA color;
+            color.a = 1.0;
+            color.r = 1.0 - angle/(2*M_PI);
+            color.g = 1.0 - angle/(2*M_PI);
+            color.b = 1.0;
+            marker.colors.push_back(color);
+        }
+        msg.markers.push_back(marker);
+    }
+    if(silly_shapes)
+    {
+        /// Add some silly shapes
+        visualization_msgs::Marker marker;
+        marker.header.frame_id = shape_frame;
+        marker.header.stamp = ros::Time::now();
+        marker.ns = "lists";
+        marker.id = 2;
+        marker.type = visualization_msgs::Marker::SPHERE_LIST;
+        marker.action = visualization_msgs::Marker::ADD;
+        marker.pose.position.x = .2;
+        marker.pose.position.y = .1;
+        marker.pose.position.z =-.5;
+        marker.scale.x = 0.02;
+        marker.scale.y = 1;
+        marker.scale.z = 1;
+        marker.pose.orientation.x = 0.443047;
+        marker.pose.orientation.y = 0.235269;
+        marker.pose.orientation.z = 0.553809;
+        marker.pose.orientation.w = 0.664570;
+        marker.color.r=0.0;
+        marker.color.g=1.0;
+        marker.color.b=1.0;
+        marker.color.a=1.0;
+        for(float angle=0.0;angle<2*M_PI;angle+=0.15){
+            geometry_msgs::Point pt;
+            pt.x = cos(angle)/6.0;
+            pt.y = sin(angle)/6.0;
+            pt.z = angle/10.0;
+            marker.points.push_back(pt);
+        }
+        msg.markers.push_back(marker);
+    }
+    if(silly_shapes)
+    {
+        /// Add some silly shapes
+        visualization_msgs::Marker marker;
+        marker.header.frame_id = shape_frame;
+        marker.header.stamp = ros::Time::now();
+        marker.ns = "lists";
+        marker.id = 3;
+        marker.type = visualization_msgs::Marker::POINTS;
+        marker.action = visualization_msgs::Marker::ADD;
+        marker.pose.position.x = .2;
+        marker.pose.position.y = .1;
+        marker.pose.position.z =-.5;
+        marker.scale.x = 0.02;
+        marker.scale.y = 1;
+        marker.scale.z = 1;
+        marker.pose.orientation.x = 0.443047;
+        marker.pose.orientation.y = 0.235269;
+        marker.pose.orientation.z = 0.553809;
+        marker.pose.orientation.w = 0.664570;
+        marker.color.r=0.0;
+        marker.color.g=1.0;
+        marker.color.b=1.0;
+        marker.color.a=1.0;
+        for(float angle=0.0;angle<2*M_PI;angle+=0.15){
+            geometry_msgs::Point pt;
+            pt.x = cos(angle)/8.0;
+            pt.y = sin(angle)/8.0;
+            pt.z = angle/10.0;
+            marker.points.push_back(pt);
+            std_msgs::ColorRGBA color;
+            color.a = 1.0;
+            color.r = angle/(2*M_PI);
+            color.g = 1.0 - angle/(2*M_PI);
+            color.b = 0.0;
+            marker.colors.push_back(color);
+        }
+        msg.markers.push_back(marker);
+    }
     /// Send a text marker at the origin of every frame we know about
     for(int idx=0;idx<tf_cache.size();idx++){
         msg.markers.push_back(frame_label(tf_cache[idx]));
@@ -208,10 +418,13 @@ int main(int argc, char** argv)
 {
   ros::init(argc, argv, "marker_test");
   ros::NodeHandle n;
+  ros::NodeHandle pnh("~");
 
   ros::Subscriber tf_sub = n.subscribe("/tf", 1, tf_Callback);
   g_marker_pub = n.advertise<visualization_msgs::MarkerArray> ("marker_array", 0);
   ros::Timer publish_timer = n.createTimer(ros::Duration(1), publishCallback);
+  pnh.getParam("silly_shapes",silly_shapes);
+  pnh.getParam("shape_frame",shape_frame);
 
   tf::TransformBroadcaster tf_broadcaster;
 

--- a/vrviz/src/marker_test.cpp
+++ b/vrviz/src/marker_test.cpp
@@ -358,16 +358,16 @@ void publishCallback(const ros::TimerEvent&)
         marker.header.frame_id = shape_frame;
         marker.header.stamp = ros::Time::now();
         marker.ns = "marker_test_mesh";
-        marker.id = 0;
+        marker.id = 42;
         marker.type = visualization_msgs::Marker::MESH_RESOURCE;
         marker.action = visualization_msgs::Marker::ADD;
-        marker.pose.position.x = 0.0;
-        marker.pose.position.y = 0.0;
-        marker.pose.position.z = 0.0;
-        marker.pose.orientation.x = 0.0;
-        marker.pose.orientation.y = 0.0;
-        marker.pose.orientation.z = 0.0;
-        marker.pose.orientation.w = 1.0;
+        marker.pose.position.x = 0.35;
+        marker.pose.position.y = 1.00;
+        marker.pose.position.z =-0.35;
+        marker.pose.orientation.x = 0.443047;
+        marker.pose.orientation.y = 0.235269;
+        marker.pose.orientation.z = 0.553809;
+        marker.pose.orientation.w = 0.664570;
         marker.scale.x = 1.0;
         marker.scale.y = 1.0;
         marker.scale.z = 1.0;
@@ -377,7 +377,9 @@ void publishCallback(const ros::TimerEvent&)
         marker.color.a = 1.0;
         marker.frame_locked = true;
         //marker.mesh_resource = "package://vrviz/meshes/flag.dae";
-        marker.mesh_resource = "package://turtlebot_description/meshes/stacks/hexagons/plate_top.dae";
+        /// The main body of the kobuki is textured and easy to recognize, so it makes a good example object.
+        /// Also, it will be installed if you have turtlebot gazebo so it should be already installed for anyone runnign turtlebot_demo.launch
+        marker.mesh_resource = "package://kobuki_description/meshes/main_body.dae";
         marker.mesh_use_embedded_materials = true;
         msg.markers.push_back(marker);
     }

--- a/vrviz/src/mesh.cpp
+++ b/vrviz/src/mesh.cpp
@@ -415,10 +415,9 @@ void Mesh::InitMarker(float scaling_factor)
             InitCube(Vertices,Indices,Vector3(radius.x,radius.x,radius.x),color,mat8);
         }
     }else if(marker.type==visualization_msgs::Marker::TEXT_VIEW_FACING){
-        float height=marker.scale.z*scaling_factor; /// Only scale.z is used. scale.z specifies the height of an uppercase "A".
-        //pVRVizApplication->AddTextToScene(mat4,texturedvertdataarray,marker.text,height);
+        /// Implimented in the main loop, since it uses the textured pipeline
     }else if(marker.type==visualization_msgs::Marker::MESH_RESOURCE){
-        /// Not implimented.
+        /// Implimented in the main loop, since it uses the textured pipeline
     }else if(marker.type==visualization_msgs::Marker::TRIANGLE_LIST){
         InitTriangles(Vertices,Indices,mat6,radius,marker.points,marker.colors,color);
     }

--- a/vrviz/src/mesh.cpp
+++ b/vrviz/src/mesh.cpp
@@ -341,11 +341,12 @@ void Mesh::InitMarker(float scaling_factor)
             mat8 = quat2mat(quatPoint2Point(gpos1,gpos2,distance));
             mat9 = mat7 * mat8;
 
-            if(idx<marker.colors.size()){
-                /// If there are per-cube colors, use those
-                color.x = marker.colors[idx].r;
-                color.y = marker.colors[idx].g;
-                color.z = marker.colors[idx].b;
+            if(idx<marker.colors.size()-1){
+                /// \warning this is supposed to blend colors from colors[idx] at points[idx] to colors[idx+1] at points[idx+1], but we don't have that ability so we just average them.
+                /// \todo figure out if we can easily do per-vertex color, since that would fix this.
+                color.x = (marker.colors[idx].r+marker.colors[idx+1].r)/2.0;
+                color.y = (marker.colors[idx].g+marker.colors[idx+1].g)/2.0;
+                color.z = (marker.colors[idx].b+marker.colors[idx+1].b)/2.0;
             }
             /// Not properly implimented. This should be a simple camera-facing quad.
             /// We use a cylinder because making things face the camera is annoying to impliment using this code.

--- a/vrviz/src/mesh.cpp
+++ b/vrviz/src/mesh.cpp
@@ -337,9 +337,9 @@ void Mesh::InitMarker(float scaling_factor)
 
             /// Translate to the average of the two points, since cylinder & cube are both centered.
             mat7.identity();
-            mat7.translate((gpos1.x+gpos2.x)/2.0*scaling_factor,
-                           (gpos1.y+gpos2.y)/2.0*scaling_factor,
-                           (gpos1.z+gpos2.z)/2.0*scaling_factor);
+            mat7.translate((gpos1.x+gpos2.x)/2.0,
+                           (gpos1.y+gpos2.y)/2.0,
+                           (gpos1.z+gpos2.z)/2.0);
             /// Also get rotation to point from one point towards the other
             mat8 = quat2mat(quatPoint2Point(gpos1,gpos2,distance));
             mat9 = mat7 * mat8;

--- a/vrviz/src/mesh.h
+++ b/vrviz/src/mesh.h
@@ -72,6 +72,7 @@ public:
 
     bool LoadMesh(const std::string& Filename);
     void InitMarker(float scaling_factor=1.0);
+    Matrix4 quat2mat(geometry_msgs::Quaternion quat);
 
     void Render();
 
@@ -81,6 +82,8 @@ public:
     bool has_texture;
     bool initialized;
     bool needs_update;
+    bool load_mesh;
+    std::string filename;
 
     visualization_msgs::Marker marker;
 
@@ -91,7 +94,6 @@ public:
 
 private:
     geometry_msgs::Quaternion quatPoint2Point(Vector4 p1, Vector4 p2, float distance);
-    Matrix4 quat2mat(geometry_msgs::Quaternion quat);
     bool InitFromScene(const aiScene* pScene, const std::string& Filename);
     Vector4 sphere2cart(float azimuth, float elevation, float radius);
     void AddColorVertex(Vector4 pt,Vector4 normal,Vector3 color, std::vector<vr::RenderModel_Vertex_t_rgb> &Vertices, std::vector<u_int32_t> &Indices);

--- a/vrviz/src/mesh.h
+++ b/vrviz/src/mesh.h
@@ -90,12 +90,15 @@ public:
     bool Z_UP;
 
 private:
+    geometry_msgs::Quaternion quatPoint2Point(Vector4 p1, Vector4 p2, float distance);
+    Matrix4 quat2mat(geometry_msgs::Quaternion quat);
     bool InitFromScene(const aiScene* pScene, const std::string& Filename);
     Vector4 sphere2cart(float azimuth, float elevation, float radius);
     void AddColorVertex(Vector4 pt,Vector4 normal,Vector3 color, std::vector<vr::RenderModel_Vertex_t_rgb> &Vertices, std::vector<u_int32_t> &Indices);
     void AddColorTri(Vector4 pt1, Vector4 pt2, Vector4 pt3, Vector3 color, std::vector<vr::RenderModel_Vertex_t_rgb> &Vertices, std::vector<u_int32_t> &Indices);
     void InitCube(std::vector<vr::RenderModel_Vertex_t_rgb> &Vertices, std::vector<u_int32_t> &Indices, Vector3 radius, Vector3 color, Matrix4 mat );
     void InitSphere(std::vector<vr::RenderModel_Vertex_t_rgb> &Vertices, std::vector<u_int32_t> &Indices, float radius, Vector3 color, Vector4 center, int num_lat=8, int num_lon=0 );
+    void InitArrow( std::vector<vr::RenderModel_Vertex_t_rgb> &Vertices, std::vector<u_int32_t> &Indices, Matrix4 mat, float radius_y,float radius_z, float length, Vector3 color, int num_facets=16 );
     void InitCylinder( std::vector<vr::RenderModel_Vertex_t_rgb> &Vertices, std::vector<u_int32_t> &Indices, Matrix4 mat, float radius, float length, Vector3 color, int num_facets=16 );
     void InitTriangles(std::vector<vr::RenderModel_Vertex_t_rgb> &Vertices, std::vector<u_int32_t> &Indices,Matrix4 mat,Vector3 radius, std::vector<geometry_msgs::Point> &points,std::vector<std_msgs::ColorRGBA> &colors, Vector3 default_color);
     void InitMesh(unsigned int Index, const aiMesh* paiMesh, const aiNode* node);

--- a/vrviz/src/openvr_gl.cpp
+++ b/vrviz/src/openvr_gl.cpp
@@ -1617,13 +1617,16 @@ void CMainApplication::RenderScene( vr::Hmd_Eye nEye )
 		glDrawArrays( GL_LINES, 0, m_uiControllerVertcount );
 		glBindVertexArray( 0 );
 
-		// draw the point cloud
-		glUseProgram( m_unControllerTransformProgramID );
-		glUniformMatrix4fv( m_nControllerMatrixLocation, 1, GL_FALSE, (GetCurrentViewProjectionMatrix( nEye ) * GetRobotMatrixPose(m_strPointCloudFrame)).get() );
-		glBindVertexArray( m_unPointCloudVAO );
-		glPointSize( m_unPointSize );
-		glDrawArrays( GL_POINTS, 0, m_uiPointCloudVertcount );
-		glBindVertexArray( 0 );
+        // Only bother drawing if there are points. This avoids calls to GetRobotMatrixPose() where m_strPointCloudFrame is an empty string.
+        if(m_uiPointCloudVertcount>0){
+            // draw the point cloud
+            glUseProgram( m_unControllerTransformProgramID );
+            glUniformMatrix4fv( m_nControllerMatrixLocation, 1, GL_FALSE, (GetCurrentViewProjectionMatrix( nEye ) * GetRobotMatrixPose(m_strPointCloudFrame)).get() );
+            glBindVertexArray( m_unPointCloudVAO );
+            glPointSize( m_unPointSize );
+            glDrawArrays( GL_POINTS, 0, m_uiPointCloudVertcount );
+            glBindVertexArray( 0 );
+        }
 
 		// draw the color triangle mesh
 		glUseProgram( m_unControllerTransformProgramID );
@@ -1653,8 +1656,11 @@ void CMainApplication::RenderScene( vr::Hmd_Eye nEye )
 
         //robot_meshes[idx]->Render();
         for(int jj=0;jj<robot_meshes[idx]->m_Entries.size();jj++){
-            if(robot_meshes[idx]->initialized){
-                //std::cout << "Rendering " << robot_meshes[idx]->name << " ID=" << robot_meshes[idx]->id << std::endl;
+            if(robot_meshes[idx]->initialized && !robot_meshes[idx]->load_mesh){
+                if(robot_meshes[idx]->frame_id.length()==0)
+                {
+                    std::cout << "empty frameid when rendering " << robot_meshes[idx]->name << " ID=" << robot_meshes[idx]->id << " FrameID=" << robot_meshes[idx]->frame_id << std::endl;
+                }
 
                 if(robot_meshes[idx]->m_Entries[jj].MaterialIndex!=NO_TEXTURE){
 

--- a/vrviz/src/vrviz_gl.cpp
+++ b/vrviz/src/vrviz_gl.cpp
@@ -1738,9 +1738,9 @@ int find_or_add_marker(visualization_msgs::Marker marker){
         ss << marker.id;
         /// \todo this needs to come from the marker pose
         Matrix4 trans;
-        trans.translate(marker.pose.position.x,
-                        marker.pose.position.y,
-                        marker.pose.position.z);
+        trans.translate(marker.pose.position.x*scaling_factor,
+                        marker.pose.position.y*scaling_factor,
+                        marker.pose.position.z*scaling_factor);
         Matrix4 rot = myMesh->quat2mat(marker.pose.orientation);
         Matrix4 full = trans*rot;
         Vector3 scale(scaling_factor,scaling_factor,scaling_factor);


### PR DESCRIPTION
Supports all 11 marker types in visualization_markers to some degree. Not fully implemented in the same way as rviz, but should cover most use cases. Meshes use the same code as for the robot_description so will have similar limitations. This addresses the feature request #3 which asked for more marker types.

Run `roslaunch vrviz turtlebot_demo.launch silly_shapes:=true` to see all the cool new marker types in action.